### PR TITLE
Add root route to avoid 404 when entering bare URL

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
 
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
+  root to: 'admin/dashboard#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Improves where users see a 404 page when entering the app's URL without specifying a path (e.g. "/admin")

Previously:
- https://progressive-coders-bot.herokuapp.com/ results in 404 page

Currently (with this change):
- https://progressive-coders-bot.herokuapp.com/ takes user to admin dashboard (or admin login page if not yet authenticated)