### PR TITLE
Improve slack experience

### DIFF
--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -6,7 +6,7 @@ class SlackController < APIController
 
   def search
     # tell the user to cool their heels
-    render json: { response_type: "ephemeral", text: "performing search" }
+    render json: { response_type: "ephemeral", text: "performing search for: #{params[:text]}" }
     Thread.new(params) { |params|
       # now send the search results to the response_url
       results = ApplicationHelper::queryUsers(params[:text].split(/\s*,\s*/))
@@ -35,7 +35,7 @@ class SlackController < APIController
       logger.debug "count > 0"
       result_str = ""
       results.each do |user|
-        result_str += user.name + "    "
+        result_str += "*#{user.name}* + "    "
         skill_list = []
         user.skills.each do |skill|
           skill_list.push(skill.name)


### PR DESCRIPTION
  - Include the search string in the immediate response to slack user.
  Helps if user makes a few searches that return zero results (hmm have
  I tried searching for xyz yet? why yes you have!)
  - Also, make the names in search results bold... when results span
  multiple lines it's hard to delineate entries because names look
  similar to skills

![image](https://user-images.githubusercontent.com/708692/34456917-365214ec-ed68-11e7-96cf-24e4e1d180b3.png)
