### PR TITLE
Bug fix

### DIFF
--- a/app/views/dashboard/projects/show.html.erb
+++ b/app/views/dashboard/projects/show.html.erb
@@ -23,7 +23,7 @@
   <% if resource.slack_channel_id.present? %>
     <% channel = resource.slack_channel_id %>
   <% else %>
-    <% channel = resource._channel %>
+    <% channel = resource.slack_channel %>
   <% end %>
   <p><b>Slack Channel:slack</b></p>
   <p><%= link_to "##{resource.slack_channel}", "slack://channel?team=T1KR8AG7J&id=#{channel}" %></p>

--- a/app/views/dashboard/projects/show.html.erb
+++ b/app/views/dashboard/projects/show.html.erb
@@ -20,8 +20,13 @@
 <p><%= resource.description %></p>
 
 <% if resource.slack_channel.present? %>
-  <p><b>Slack Channel:</b></p>
-  <p><%= link_to '#' + resource.slack_channel, 'slack://channel?team=T1KR8AG7J&id=' + resource.slack_channel_id %></p>
+  <% if resource.slack_channel_id.present? %>
+    <% channel = resource.slack_channel_id %>
+  <% else %>
+    <% channel = resource._channel %>
+  <% end %>
+  <p><b>Slack Channel:slack</b></p>
+  <p><%= link_to "##{resource.slack_channel}", "slack://channel?team=T1KR8AG7J&id=#{channel}" %></p>
 <% end %>
 
 


### PR DESCRIPTION
has to do with why our show pages for projects were frequently crashing in production. the slack channels were imported awhile ago and the addition of 'slack channel id' was more recent, so the database didn't have that even if it had a slack channel. i decided to use the slack channel name if there's no slack channel id. we could always use the slack channel name but my thinking is if you have the id and it's more likely to be accurate why not use it. let me know what you think