### PR TITLE
no email is empty string instead of nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -218,8 +218,12 @@ class User < ApplicationRecord
 
     self.is_approved = true
 
-    if self.email.blank? && self.has_slack?
-      self.get_email_from_slack
+    if self.email.blank?
+      if self.has_slack?
+        self.get_email_from_slack
+      else
+        self.email = ""
+      end
     end
 
     if self.slack_userid.blank? && self.slack_username.present?


### PR DESCRIPTION
Our users table has a default "" for email but doesn't allow nil. When we get email from airtable and it's blank it's nil not an empty string. So I'm just changing nil to an empty string.